### PR TITLE
Improve Javadoc coverage for paquete package

### DIFF
--- a/src/paquete/Catalogo.java
+++ b/src/paquete/Catalogo.java
@@ -1,16 +1,15 @@
 package paquete;
 
-/**
- * Representa un catálogo de contenidos multimedia.
- * Permite buscar contenidos, filtrar por género y agregar nuevos contenidos.
- * 
- * @author Grupo32 
- * @version 1.0
-
- */ 
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Representa un catálogo de contenidos multimedia.
+ * Permite buscar contenidos, filtrar por género y agregar nuevos contenidos.
+ *
+ * @author Grupo32
+ * @version 1.0
+ */
 public class Catalogo {
     private List<Contenido> listaDeContenidos;  
     private int cantidadDeContenidos;          
@@ -33,8 +32,7 @@ public class Catalogo {
         int i = 0;
         while (i < listaDeContenidos.size()) {
             Contenido c = listaDeContenidos.get(i);
-            if (c.getTitulo() != null && c.getTitulo().
-            equalsIgnoreCase(titulo)) {
+            if (c.getTitulo() != null && c.getTitulo().equalsIgnoreCase(titulo)) {
                 return c;
             }
             i++;
@@ -69,12 +67,36 @@ public class Catalogo {
     }
 
     // --- Getters & Setters ---
+
+    /**
+     * Obtiene la lista completa de contenidos del catálogo.
+     *
+     * @return lista de contenidos registrados.
+     */
     public List<Contenido> getListaDeContenidos() { return listaDeContenidos; }
+
+    /**
+     * Reemplaza la lista completa de contenidos del catálogo.
+     * También actualiza la cantidad total de elementos registrados.
+     *
+     * @param listaDeContenidos nueva lista de contenidos a utilizar.
+     */
     public void setListaDeContenidos(List<Contenido> listaDeContenidos) {
         this.listaDeContenidos = listaDeContenidos;
         this.cantidadDeContenidos = (listaDeContenidos != null) ? listaDeContenidos.size() : 0;
     }
 
+    /**
+     * Devuelve la cantidad total de contenidos almacenados en el catálogo.
+     *
+     * @return número de contenidos cargados.
+     */
     public int getCantidadDeContenidos() { return cantidadDeContenidos; }
+
+    /**
+     * Establece manualmente la cantidad de contenidos del catálogo.
+     *
+     * @param cantidadDeContenidos nuevo valor para la cantidad total.
+     */
     public void setCantidadDeContenidos(int cantidadDeContenidos) { this.cantidadDeContenidos = cantidadDeContenidos; }
 }

--- a/src/paquete/Contenido.java
+++ b/src/paquete/Contenido.java
@@ -1,4 +1,8 @@
 package paquete;
+
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Clase abstracta que representa un contenido audiovisual.
  * Contiene atributos comunes como título, descripción, director, actores,
@@ -9,13 +13,7 @@ package paquete;
  *
  * @author grupo32
  * @version 1.0
-
-
  */
-import java.util.ArrayList;
-import java.util.List;
-
-
 public abstract class Contenido {
     private String titulo;
     private String descripcion;
@@ -36,30 +34,119 @@ public abstract class Contenido {
     }
 
     // --- Getters & Setters ---
+
+    /**
+     * Obtiene el título del contenido.
+     *
+     * @return título asignado al contenido.
+     */
     public String getTitulo() { return titulo; }
+
+    /**
+     * Define el título del contenido.
+     *
+     * @param titulo nuevo título a establecer.
+     */
     public void setTitulo(String titulo) { this.titulo = titulo; }
 
+    /**
+     * Recupera la descripción general del contenido.
+     *
+     * @return descripción textual del contenido.
+     */
     public String getDescripcion() { return descripcion; }
+
+    /**
+     * Establece la descripción del contenido.
+     *
+     * @param descripcion texto descriptivo a asignar.
+     */
     public void setDescripcion(String descripcion) { this.descripcion = descripcion; }
 
+    /**
+     * Devuelve el nombre del director asociado al contenido.
+     *
+     * @return director responsable de la obra.
+     */
     public String getDirector() { return director; }
+
+    /**
+     * Asigna el nombre del director del contenido.
+     *
+     * @param director nombre del director a almacenar.
+     */
     public void setDirector(String director) { this.director = director; }
 
+    /**
+     * Proporciona la lista de actores participantes.
+     *
+     * @return lista de nombres de actores.
+     */
     public List<String> getActores() { return actores; }
+
+    /**
+     * Reemplaza la lista de actores asociados al contenido.
+     *
+     * @param actores nueva lista de nombres de actores.
+     */
     public void setActores(List<String> actores) { this.actores = actores; }
 
+    /**
+     * Obtiene el género del contenido.
+     *
+     * @return nombre del género principal.
+     */
     public String getGenero() { return genero; }
+
+    /**
+     * Actualiza el género del contenido.
+     *
+     * @param genero etiqueta de género a establecer.
+     */
     public void setGenero(String genero) { this.genero = genero; }
 
+    /**
+     * Devuelve la lista de países en los que existe alguna restricción de visualización.
+     *
+     * @return lista de códigos o nombres de países restringidos.
+     */
     public List<String> getRestriccionesGeograficas() { return restriccionesGeograficas; }
+
+    /**
+     * Establece las restricciones geográficas asociadas al contenido.
+     *
+     * @param restriccionesGeograficas colección de países restringidos.
+     */
     public void setRestriccionesGeograficas(List<String> restriccionesGeograficas) {
         this.restriccionesGeograficas = restriccionesGeograficas;
     }
 
+    /**
+     * Obtiene el tipo de contenido representado (por ejemplo, serie o metraje).
+     *
+     * @return tipo de contenido configurado.
+     */
     public String getTipoDeContenido() { return tipoDeContenido; }
+
+    /**
+     * Define el tipo de contenido representado.
+     *
+     * @param tipoDeContenido descripción del tipo de contenido.
+     */
     public void setTipoDeContenido(String tipoDeContenido) { this.tipoDeContenido = tipoDeContenido; }
 
+    /**
+     * Obtiene el identificador único del contenido.
+     *
+     * @return identificador numérico asignado.
+     */
     public long getId() { return id; }
+
+    /**
+     * Establece el identificador único del contenido.
+     *
+     * @param id identificador a asignar.
+     */
     public void setId(long id) { this.id = id; }
 
     // --- Métodos para actores ---

--- a/src/paquete/Metraje.java
+++ b/src/paquete/Metraje.java
@@ -14,7 +14,6 @@ package paquete;
  *
  * @author Grupo32
  * @version 1.0
-
  */
 public class Metraje extends Contenido {
     private Integer duracion;       // minutos
@@ -27,13 +26,46 @@ public class Metraje extends Contenido {
      */
     public Metraje() {}
 
+    /**
+     * Devuelve la duración total del metraje en minutos.
+     *
+     * @return duración expresada en minutos.
+     */
     public Integer getDuracion() { return duracion; }
+
+    /**
+     * Establece la duración total del metraje en minutos.
+     *
+     * @param duracion duración del contenido en minutos.
+     */
     public void setDuracion(Integer duracion) { this.duracion = duracion; }
 
+    /**
+     * Obtiene el idioma de audio principal del metraje.
+     *
+     * @return idioma del audio disponible.
+     */
     public String getAudio() { return audio; }
+
+    /**
+     * Define el idioma de audio principal del metraje.
+     *
+     * @param audio idioma del audio a configurar.
+     */
     public void setAudio(String audio) { this.audio = audio; }
 
+    /**
+     * Recupera los subtítulos disponibles para el metraje.
+     *
+     * @return idioma o descripción de los subtítulos.
+     */
     public String getSubtitulos() { return subtitulos; }
+
+    /**
+     * Configura los subtítulos disponibles para el metraje.
+     *
+     * @param subtitulos idioma o descripción de los subtítulos.
+     */
     public void setSubtitulos(String subtitulos) { this.subtitulos = subtitulos; }
 
     /**

--- a/src/paquete/Serie.java
+++ b/src/paquete/Serie.java
@@ -1,5 +1,8 @@
 package paquete;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * La clase Serie representa un tipo de Contenido compuesto por varias temporadas.
  * Cada temporada puede incluir distintos episodios u otras características
@@ -13,9 +16,6 @@ package paquete;
  * @author grupo32
  * @version 1.0
  */
-
- import java.util.ArrayList;
-import java.util.List;
 public class Serie extends Contenido {
 
     private List<Temporada> temporadas;   // Lista de temporadas
@@ -29,7 +29,19 @@ public class Serie extends Contenido {
     }
 
     // --- Getters & Setters ---
+
+    /**
+     * Obtiene la lista de temporadas que componen la serie.
+     *
+     * @return lista de objetos {@link Temporada} registrados.
+     */
     public List<Temporada> getTemporadas() { return temporadas; }
+
+    /**
+     * Reemplaza la lista de temporadas asociada a la serie.
+     *
+     * @param temporadas colección de temporadas que describen la serie.
+     */
     public void setTemporadas(List<Temporada> temporadas) {
         this.temporadas = temporadas;
     }

--- a/src/paquete/Temporada.java
+++ b/src/paquete/Temporada.java
@@ -1,20 +1,22 @@
 package paquete;
 
-/**
- * Representa una temporada de una serie, compuesta por una lista de capítulos (Metraje).
- * Proporciona métodos para buscar y devolver capítulos, así como para gestionar la cantidad de episodios.
- * 
- * @author Grupo32
- * @version 1.0
- */
-
-
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Representa una temporada de una serie, compuesta por una lista de capítulos (Metraje).
+ * Proporciona métodos para buscar y devolver capítulos, así como para gestionar la cantidad de episodios.
+ *
+ * @author Grupo32
+ * @version 1.0
+ */
 public class Temporada {
-    private List<Metraje> capitulos;   
-    private Integer cantidadDeEpisodios;     
+    private List<Metraje> capitulos;
+    private Integer cantidadDeEpisodios;
+
+    /**
+     * Crea una temporada vacía con cero episodios registrados inicialmente.
+     */
     public Temporada() {
         this.capitulos = new ArrayList<>();
         this.cantidadDeEpisodios = 0;
@@ -39,9 +41,9 @@ public class Temporada {
         return false;
     }
     
-    // devolverCapitulo
     /**
      * Devuelve el capítulo correspondiente al número especificado.
+     *
      * @param numeroCapitulo El número del capítulo (comenzando desde 1).
      * @return El objeto Metraje correspondiente al número de capítulo, o null si no existe.
      */
@@ -63,6 +65,12 @@ public class Temporada {
      * @return Una lista de objetos Metraje que representan los capítulos de la temporada.
      */
     public List<Metraje> getCapitulos() { return capitulos; }
+
+    /**
+     * Reemplaza la lista completa de capítulos de la temporada y actualiza la cantidad registrada.
+     *
+     * @param capitulos nueva colección de capítulos para la temporada.
+     */
     public void setCapitulos(List<Metraje> capitulos) {
         this.capitulos = capitulos;
         this.cantidadDeEpisodios = (capitulos != null) ? capitulos.size() : 0;

--- a/src/paquete/package-info.java
+++ b/src/paquete/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Proporciona las clases del dominio para la plataforma de streaming de ejemplo.
+ * Incluye representaciones de contenidos audiovisuales, catálogos y temporadas.
+ */
+package paquete;


### PR DESCRIPTION
## Summary
- reordené imports y comentarios de clase para que Javadoc asocie la documentación con cada tipo público del paquete `paquete`
- documenté getters, setters y constructores con comentarios Javadoc detallados para eliminar advertencias
- añadí `package-info.java` para describir el paquete a nivel global

## Testing
- javac -d bin $(find src -name '*.java')
- javadoc -d docs/javadoc -sourcepath src paquete


------
https://chatgpt.com/codex/tasks/task_e_68c87dab2c088329805e4719bb3bd40e